### PR TITLE
fix for speaker detail card

### DIFF
--- a/lib/core/ui/speaker_detail_content.dart
+++ b/lib/core/ui/speaker_detail_content.dart
@@ -161,18 +161,21 @@ class _SpeakerInfo extends StatelessWidget {
                 ? MainAxisAlignment.center
                 : MainAxisAlignment.start,
             children: [
-              _SocialMediaButton(
-                icon: MdiIcons.github,
-                url: 'https://www.github.com/${speaker.github}',
-              ),
-              _SocialMediaButton(
-                icon: MdiIcons.linkedin,
-                url: 'https://www.linkedin.com/in/${speaker.linkedin}',
-              ),
-              _SocialMediaButton(
-                icon: MdiIcons.twitter,
-                url: 'https://www.twitter.com/${speaker.twitter}',
-              ),
+              if (speaker.github != null)
+                _SocialMediaButton(
+                  icon: MdiIcons.github,
+                  url: 'https://www.github.com/${speaker.github}',
+                ),
+              if (speaker.linkedin != null)
+                _SocialMediaButton(
+                  icon: MdiIcons.linkedin,
+                  url: 'https://www.linkedin.com/in/${speaker.linkedin}',
+                ),
+              if (speaker.twitter != null)
+                _SocialMediaButton(
+                  icon: MdiIcons.twitter,
+                  url: 'https://www.twitter.com/${speaker.twitter}',
+                ),
             ],
           ),
         ],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30979744/163376565-2c56074b-e302-402b-9550-6e3cb0ea8e1d.png)
When data is null shows social media widget and when clicked launches "github.com/null".